### PR TITLE
BACKLOG-23579: Updated version of the jahia plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <jahia-module-type>system</jahia-module-type>
         <yarn.arguments>build:production</yarn.arguments>
         <jahia-module-signature>MCsCFH9QdJwipQWs86/3Qyxho2FpkBz7AhN5kF+pQdu35W9BMgC6ztF9J4p/</jahia-module-signature>
-        <jahia.plugin.version>6.10</jahia.plugin.version>
+        <jahia.plugin.version>6.9</jahia.plugin.version>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
         <jahia-module-type>system</jahia-module-type>
         <yarn.arguments>build:production</yarn.arguments>
         <jahia-module-signature>MCsCFH9QdJwipQWs86/3Qyxho2FpkBz7AhN5kF+pQdu35W9BMgC6ztF9J4p/</jahia-module-signature>
+        <jahia.plugin.version>6.10</jahia.plugin.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
https://jira.jahia.org/browse/BACKLOG-23579

Trying to address this error during the last release attempt:
https://github.com/Jahia/jahia-dashboard-docs/actions/runs/12989681067/job/36223192063
```
[INFO] [INFO] --- jahia:6.7:dependencies (prepare-package-dependencies) @ jahia-dashboard-docs ---
Warning: ARNING] Error injecting: org.jahia.utils.maven.plugin.osgi.DependenciesMojo
[INFO] java.lang.NoClassDefFoundError: Lorg/jahia/utils/osgi/parsers/ParsingContext;
[INFO]     at java.lang.Class.getDeclaredFields0 (Native Method)
[INFO]     at java.lang.Class.privateGetDeclaredFields (Class.java:3061)
```